### PR TITLE
added ENV option for defining service addresses

### DIFF
--- a/src/main/java/org/streampipes/examples/flink/config/FlinkConfig.java
+++ b/src/main/java/org/streampipes/examples/flink/config/FlinkConfig.java
@@ -41,14 +41,38 @@ public enum FlinkConfig implements PeConfig {
   FlinkConfig() {
     config = SpConfig.getSpConfig(SERVICE_ID);
 
-    config.register(HOST, "pe-examples-flink", "Hostname for the pe mixed flink component");
-    config.register(PORT, 8090, "Port for the pe mixed flink component");
-    config.register(FLINK_HOST, "jobmanager", "Host for the flink cluster");
-    config.register(FLINK_PORT, 6123, "Port for the flink cluster");
-    config.register(ELASTIC_HOST, "elasticsearch", "Elastic search host address");
-    config.register(ELASTIC_PORT, 9300, "Elasitc search port");
+    /*
+      FOR CONFIGURING SERVICES VIA ENVIRONMENT VARIABLES
+     */
+    String peHost = System.getenv("PE_HOST");
+    String flinkHost = System.getenv("FLINK_HOST");
+    String elasticHost = System.getenv("ELASTIC_HOST");
+    String iconHost = System.getenv("ICON_HOST");
 
-    config.register(ICON_HOST, "backend", "Hostname for the icon host");
+    if (peHost != null && !peHost.isEmpty())
+      config.register(HOST, peHost, "Hostname for the pe mixed flink component");
+    else
+      config.register(HOST, "pe-examples-flink", "Hostname for the pe mixed flink component");
+
+    if (flinkHost != null && !flinkHost.isEmpty())
+      config.register(FLINK_HOST, flinkHost, "Host for the flink cluster");
+    else
+      config.register(FLINK_HOST, "jobmanager", "Host for the flink cluster");
+
+    if (elasticHost != null && !elasticHost.isEmpty())
+      config.register(ELASTIC_HOST, elasticHost, "Elastic search host address");
+    else
+      config.register(ELASTIC_HOST, "elasticsearch", "Elastic search host address");
+
+    if (iconHost != null && !iconHost.isEmpty())
+      config.register(ICON_HOST, iconHost, "Hostname for the icon host");
+    else
+      config.register(ICON_HOST, "backend", "Hostname for the icon host");
+
+
+    config.register(PORT, 8090, "Port for the pe mixed flink component");
+    config.register(FLINK_PORT, 6123, "Port for the flink cluster");
+    config.register(ELASTIC_PORT, 9300, "Elasitc search port");
     config.register(ICON_PORT, 80, "Port for the icons in nginx");
 
     config.register(SERVICE_NAME, "Mixed Flink", "The name of the service");


### PR DESCRIPTION
**Problem:** 
IP addresses of backend services (Flink, Consul, etc.) are hard coded and specifically aim for local deployment only, where service names are DNS resolvable. However, in a cluster setup, e.g. within Rancher when not deploying all services within the same stack the services names are not resolvable other than `<servicename>.<stackname>`. Therefore, one would need to change the service name in consul after deployment.

**Solution:**
In order to deploy the PE's in a cluster environment, it might be useful to pre-specify the service addresses such that the PE itself is registrating the correct IP's within Consul in advance. So you could easily configure the addresses while starting the corresponding docker container (excerpt from the `docker-compose.yml` for Rancher):

```yaml
  pe-examples-flink:
    image: registry.biggis.project.de/streampipes/pe-examples-flink:0.51.2-rancher
    ports:
      - "8097:8090"
    environment:
      - PE_HOST=pe-examples-flink.nodes
      - CONSUL_LOCATION=consul.storage
      - FLINK_HOST=flink-jobmanager.analytics
      - ELASTIC_HOST=elasticsearch.storage
      - ICON_HOST=backend.modelling
    labels:
      io.rancher.container.pull_image: always
    logging:
      driver: "json-file"
      options:
        max-size: "1m"
        max-file: "1"
```